### PR TITLE
Fix build errors on Windows

### DIFF
--- a/lib/create-tpl-bundle.js
+++ b/lib/create-tpl-bundle.js
@@ -19,7 +19,7 @@ module.exports = function createBuildTemplates(grunt) {
                     tpls : sources.map(function(source) {
                         return {
                             name : source.replace(grunt.config.get('baseDirs.src'), '')
-                            , path : path.join('..','..', source)
+                            , path : '../../' + source
                         }
                     })
                 }


### PR DESCRIPTION
`lib/create-tpl-bundle.js` uses `path.join()` to generate require('..') statements in `template-list.js`. Since on Windows `path.join()` uses backslashes as folder delimiters, the resulting strings end up containing escape sequences when a folder name starts with a letter like 'n' or 't' etc. Forward-slashes, on the other hand, are fully supported on Windows as well, so hard-coding those will make it work on Windows, and won't break anything for other platforms.

Example `template-list.js` output on Windows without the fix:
```
        $templateCache.put("/analyze-drop-zone/numeric-graph-count.html", require("..\..\src\analyze-drop-zone\numeric-graph-count.html"));
        $templateCache.put("/analyze-drop-zone/numeric-graph-group-only.html", require("..\..\src\analyze-drop-zone\numeric-graph-group-only.html"));
        $templateCache.put("/analyze-drop-zone/numeric-graph-measure-only.html", require("..\..\src\analyze-drop-zone\numeric-graph-measure-only.html"));
        $templateCache.put("/analyze-drop-zone/numeric-table-count.html", require("..\..\src\analyze-drop-zone\numeric-table-count.html"));
```