### PR TITLE
Fix bad numeric filter missing munging 94106294

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crunch-js-components",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "main": "src/crunch/index.js",
   "scripts": {
     "test": "grunt test"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crunch-js-components",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "main": "src/crunch/index.js",
   "scripts": {
     "test": "grunt test"

--- a/src/filter-builder/base-expression-builder.js
+++ b/src/filter-builder/base-expression-builder.js
@@ -175,7 +175,7 @@ function BaseExpressionBuilderProvider(machina, _, iResourceVariable) {
                     return it.isSelected
                 })
                 .map(function(cat) {
-                    return cat.id
+                    return cat.entryId
                 })
                 .value()
 

--- a/src/filter-builder/numerical-expression-builder.js
+++ b/src/filter-builder/numerical-expression-builder.js
@@ -1,15 +1,49 @@
 module.exports = NumericExpressionBuilderProvider
 
 NumericExpressionBuilderProvider.$inject = [
-        'BaseExpressionBuilder'
-    ]
+    'BaseExpressionBuilder'
+    ,'lodash'
+]
 
 
-function NumericExpressionBuilderProvider(BaseExpressionBuilder) {
+function NumericExpressionBuilderProvider(BaseExpressionBuilder, _) {
 
     var NumericExpressionBuilder = BaseExpressionBuilder.extend({
         expType: 'numeric'
         , valueArg: 'value'
+        , build : function(variablePrefix, variableSuffix) {
+            if (!this.hasSource) {
+                return NULL
+            }
+
+            var cats = _(this.categories)
+                .filter(function(it) {
+                    return it.isSelected
+                })
+                .map(function(cat) {
+                    return cat.entryId
+                })
+                .value()
+
+            var varUrl = this.variableUrl(variablePrefix, variableSuffix)
+            var r = {
+                'function': 'in'
+                , args: [{variable: varUrl}
+                         ,{column: cats
+                           , type: {
+                                'function': "typeof",
+                                args: [ {"variable": varUrl}]
+                           }
+                      }
+                ]
+            }
+            if (this.negated){
+                r = {'function': 'not',
+                     'args': [r]
+                    }
+            }
+            return r
+        }
     })
 
     NumericExpressionBuilder.create = function(isExclusion) {

--- a/src/filter-builder/numerical-expression-builder.js
+++ b/src/filter-builder/numerical-expression-builder.js
@@ -2,48 +2,14 @@ module.exports = NumericExpressionBuilderProvider
 
 NumericExpressionBuilderProvider.$inject = [
     'BaseExpressionBuilder'
-    ,'lodash'
 ]
 
 
-function NumericExpressionBuilderProvider(BaseExpressionBuilder, _) {
+function NumericExpressionBuilderProvider(BaseExpressionBuilder) {
 
     var NumericExpressionBuilder = BaseExpressionBuilder.extend({
         expType: 'numeric'
         , valueArg: 'value'
-        , build : function(variablePrefix, variableSuffix) {
-            if (!this.hasSource) {
-                return NULL
-            }
-
-            var cats = _(this.categories)
-                .filter(function(it) {
-                    return it.isSelected
-                })
-                .map(function(cat) {
-                    return cat.entryId
-                })
-                .value()
-
-            var varUrl = this.variableUrl(variablePrefix, variableSuffix)
-            var r = {
-                'function': 'in'
-                , args: [{variable: varUrl}
-                         ,{column: cats
-                           , type: {
-                                'function': "typeof",
-                                args: [ {"variable": varUrl}]
-                           }
-                      }
-                ]
-            }
-            if (this.negated){
-                r = {'function': 'not',
-                     'args': [r]
-                    }
-            }
-            return r
-        }
     })
 
     NumericExpressionBuilder.create = function(isExclusion) {

--- a/src/filter-builder/tests/numeric-expression-builder-spec.js
+++ b/src/filter-builder/tests/numeric-expression-builder-spec.js
@@ -117,9 +117,16 @@ module.exports = (function() {
                 $httpBackend.flush()
             });
             it('should return a filter based on selected values', function() {
+                // Select a missing category
+                sut.categories['?-1'].isSelected = true;
+                sut.categories[12].isSelected = true;
                 var build = sut.build();
                 build.function.should.equal('in');
                 build.args[0].variable.should.equal('myid');
+                // Built the right .column
+                build.args[1].column[0].should.equal(12);
+                // Check that the missing value got correctly included
+                build.args[1].column[1]['?'].should.equal(-1);
             })
         });
         describe('When decompiling', function() {


### PR DESCRIPTION
The bug was that in order to key the categories we munge the missing objects into a '?#' string so it doesn't clash with actual numeric values being used as "category" id.

We were using that munged value (the `.id` attr) to construct the filter syntax sent back. This fix changes the `build()` function to use the `.entryId` attribute that contains the original value before munging.

This was done on the `BaseExpressionBuilder` since it affects all non strictly categorical types, for all cases it is correct to send out the original value received as `id`.

On the test for numeric expressions I made sure that a missing and a non missing value are selected and that they are correctly encoded on the built expression.