### PR TITLE
fix deck's scrolling on firefox

### DIFF
--- a/src/analyses-tray/class.styl
+++ b/src/analyses-tray/class.styl
@@ -65,6 +65,8 @@
     box-shadow -1px 0 0px 0 #ffffff
     transition right ease-out 0.2s, opacity 0.1s linear
     opacity 0
+    display flex
+    flex-direction column
 
     &.opened
         right 0
@@ -72,14 +74,16 @@
         opacity 1
 
     .wrapper
+        flex-shrink 1
+        flex-grow 1
         display flex
         flex-direction column
         align-items center
         justify-content flex-start
+        overflow-y auto
 
         ul.slides-list
-            flex-basis calc(100% - 120px)
-            height calc(100% - 63px)
+            flex-shrink 1
             flex-grow 1
             overflow-y auto
             overflow-x hidden
@@ -94,7 +98,7 @@
 
 
                 &:first-child
-                    margin-top 0px
+                    margin-top 0
 
                 &:hover
                     cursor pointer
@@ -168,7 +172,7 @@
             font-size 20px
             margin-left 3px
             vertical-align middle
-            
+
 
         &:hover
             background-color color-sidebar-dark-grey


### PR DESCRIPTION
The vertical scroll bar in the analyses deck component doesn't appear on firefox.